### PR TITLE
Dryrun TIH bot in CI

### DIFF
--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -1,0 +1,27 @@
+name: "Dryrun TIH bot"
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  dryrun-tih-bot:
+    strategy:
+      fail-fast: false
+      # Linux runner
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+
+      - name: "Dryrun bot"
+        run: |
+          set -euxo pipefail
+          cd ${{ github.workspace }}/
+          make install
+          TIH_DRYRUN=1 ./twitbot-tih-run.sh

--- a/.github/workflows/runbot.yml
+++ b/.github/workflows/runbot.yml
@@ -5,7 +5,7 @@ on:
     - cron: '42 9,21 * * *'
 
 jobs:
-  run-iwpt-bot:
+  run-tih-bot:
     strategy:
       fail-fast: false
       # Linux runner

--- a/today_in_history_bot.py
+++ b/today_in_history_bot.py
@@ -61,7 +61,8 @@ def get_events_list(date_str):
     # Use some heuristics to take into account of recent wikipedia page format
     # changes
     maybe_events = [page.section(page.sections[i]) for i in
-        range(page.sections.index('Events'), page.sections.index('Births'))]
+                    range(page.sections.index('Events'),
+                          page.sections.index('Births'))]
     # Drop empty string
     events = '\n'.join([e.strip() for e in maybe_events if e.strip()])
     events_list = events.splitlines()
@@ -104,6 +105,9 @@ def do_tweet(tweet_str):
 
 
 if __name__ == '__main__':
-    twt_str = get_tweet_str()
-    print(twt_str)
-    do_tweet(twt_str)
+    TWT_STR = get_tweet_str()
+    print(TWT_STR)
+    # Set environment variable TIH_DRYRUN to any non-empty value to skip tweet
+    # publication
+    if not os.environ.get('TIH_DRYRUN'):
+        do_tweet(TWT_STR)


### PR DESCRIPTION
If environment variable `TIH_DRYRUN` is set to any non-empty value, skip publication of tweet.

Add a GitHub Actions workflow to dryrun the bot.