### PR TITLE
Use tweepy as twitter client for api v2

### DIFF
--- a/.github/workflows/runbot.yml
+++ b/.github/workflows/runbot.yml
@@ -23,7 +23,7 @@ jobs:
           make install
           ./twitbot-tih-run.sh
         env:
-          TIH_APP_KEY: '${{ secrets.TIH_APP_KEY }}'
-          TIH_APP_SECRET: '${{ secrets.TIH_APP_SECRET }}'
-          TIH_OAUTH_TOKEN: '${{ secrets.TIH_OAUTH_TOKEN }}'
-          TIH_OAUTH_TOKEN_SECRET: '${{ secrets.TIH_OAUTH_TOKEN_SECRET }}'
+          TIH_API_KEY: '${{ secrets.TIH_API_KEY }}'
+          TIH_API_SECRET: '${{ secrets.TIH_API_SECRET }}'
+          TIH_ACCESS_TOKEN: '${{ secrets.TIH_ACCESS_TOKEN }}'
+          TIH_ACCESS_TOKEN_SECRET: '${{ secrets.TIH_ACCESS_TOKEN_SECRET }}'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.auth
+*.bak
+venv
+tih_venv

--- a/README.md
+++ b/README.md
@@ -27,17 +27,19 @@ A Twitter bot that tweets today-in-history events.
 2. Create a Twitter app and obtain the API Key, API Secret, Access Token, and
    Access Token Secret for the app. This can be done by following the
    instructions at:
-   <http://www.instructables.com/id/Raspberry-Pi-Twitterbot/?ALLSTEPS>. After April 2023, if you start
-   seeing API authentication errors, and a message like "This app has violated
-   Twitter rules and policies" on the Twitter app setting page, sign up for the
-   Free tier of "[Twitter API
+   <https://developer.twitter.com/en/docs/twitter-api/getting-started/getting-access-to-the-twitter-api>.
+   After April 2023, if you start seeing API authentication errors, and a
+   message like "This app has violated Twitter rules and policies" on the
+   Twitter app setting page, sign up for the Free tier of "[Twitter API
    v2](https://developer.twitter.com/en/portal/products)" (at no cost), and
    clicked button "downgrade to free"; this resolved the auth issue
    ([reference](https://twittercommunity.com/t/this-app-has-violated-twitter-rules-and-policies/191204/10)).
+   You may also need to put the Twitter app under a "project" for better
+   organization and monitoring of the app.
 
 3. Set up authentication and authorization secrets. The preferred way is to set
-   environment variables `TIH_APP_KEY`, `TIH_APP_SECRET`, `TIH_OAUTH_TOKEN`,
-   and `TIH_OAUTH_TOKEN_SECRET` with API Key, API Secret, Access Token, and
+   environment variables `TIH_API_KEY`, `TIH_API_SECRET`, `TIH_ACCESS_TOKEN`,
+   and `TIH_ACCESS_TOKEN_SECRET` with API Key, API Secret, Access Token, and
    Access Token Secret values obtained in the last step. Alternatively, one can
    override the corresponding strings in the file [.auth](./.auth) with
    appropriate secret strings. When any of the aforementioned environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 setuptools
 # workaround bug https://stackoverflow.com/questions/34869597/wikipedia-api-for-python
 git+https://github.com/lucasdnd/Wikipedia.git
-twython
-pyOpenSSL
-ndg-httpsclient
-pyasn1
+tweepy==4.14.0
+pyOpenSSL==23.2.0
+ndg-httpsclient==0.5.1
+pyasn1==0.5.0

--- a/today_in_history_bot.py
+++ b/today_in_history_bot.py
@@ -8,7 +8,7 @@ import random
 import subprocess
 from datetime import datetime
 import wikipedia
-from twython import Twython
+import tweepy
 
 
 CRED_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -16,19 +16,20 @@ CRED_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 TWITTER_ALLOWED_CHAR = 260
 
 
-def get_api_token():
-    ''' Obtain Twitter app's API token values from envirnoment or file .auth.
-    If any of environment variables TIH_APP_KEY, TIH_APP_SECRET,
-    TIH_OAUTH_TOKEN, TIH_OAUTH_TOKEN_SECRET exist, they override the
-    corresponding secret values in file .auth.
+def get_app_credential():
+    ''' Obtain Twitter app's credential from envirnoment or file .auth
+
+    If any of environment variables TIH_API_KEY, TIH_API_SECRET,
+    TIH_ACCESS_TOKEN, TIH_ACCESS_TOKEN_SECRET exist, they override the
+    corresponding secret values in file .auth
 
     Returns list
     '''
-    app_key = os.environ.get('TIH_APP_KEY')
-    app_secret = os.environ.get('TIH_APP_SECRET')
-    oauth_token = os.environ.get('TIH_OAUTH_TOKEN')
-    oauth_token_secret = os.environ.get('TIH_OAUTH_TOKEN_SECRET')
-    credential = [app_key, app_secret, oauth_token, oauth_token_secret]
+    api_key = os.environ.get('TIH_API_KEY')
+    api_secret = os.environ.get('TIH_API_SECRET')
+    access_token = os.environ.get('TIH_ACCESS_TOKEN')
+    access_token_secret = os.environ.get('TIH_ACCESS_TOKEN_SECRET')
+    credential = [api_key, api_secret, access_token, access_token_secret]
 
     if os.path.exists(CRED_FILE):
         with open(CRED_FILE, 'r', encoding='utf-8') as fil:
@@ -101,10 +102,14 @@ def do_tweet(tweet_str):
     ''' Tweet twt_str to Twitter
 
     '''
-    [apikey, apisecret, accesstoken, accesstokensecret] = get_api_token()
-    api = Twython(apikey, apisecret, accesstoken, accesstokensecret)
-    api.update_status(status=tweet_str)
+    [apikey, apisecret, accesstoken, accesstokensecret] = get_app_credential()
+    client = tweepy.Client(consumer_key=apikey,
+                           consumer_secret=apisecret,
+                           access_token=accesstoken,
+                           access_token_secret=accesstokensecret)
+    response = client.create_tweet(text=tweet_str)
     print("Tweeted: ", tweet_str)
+    print(response)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Switch from twython to tweepy, for Twitter API v2 support. Update README.md for new app and credential setup instructions. Rename environment variables for app credential.