### PR TITLE
Remove lucasdnd/Wikipedia from deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@
 
 setuptools
 # workaround bug https://stackoverflow.com/questions/34869597/wikipedia-api-for-python
-git+https://github.com/lucasdnd/Wikipedia.git
+#git+https://github.com/lucasdnd/Wikipedia.git
+wikipedia==1.4.0
 tweepy==4.14.0
 pyOpenSSL==23.2.0
 ndg-httpsclient==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 --index-url https://pypi.python.org/simple/
 
 setuptools
-# workaround bug https://stackoverflow.com/questions/34869597/wikipedia-api-for-python
-#git+https://github.com/lucasdnd/Wikipedia.git
 wikipedia==1.4.0
 tweepy==4.14.0
 pyOpenSSL==23.2.0

--- a/today_in_history_bot.py
+++ b/today_in_history_bot.py
@@ -59,16 +59,18 @@ def get_events_list(date_str):
 
     Returns list
     '''
-    page = wikipedia.WikipediaPage(title=str(date_str))
+    content = wikipedia.WikipediaPage(title=str(date_str)).content
+    # Split the content into lines, dropping empty lines
+    lines = [line for line in content.splitlines() if line.strip()]
     # Use some heuristics to take into account of recent wikipedia page format
     # changes
-    maybe_events = [page.section(page.sections[i]) for i in
-                    range(page.sections.index('Events'),
-                          page.sections.index('Births'))]
-    # Drop empty string
-    events = '\n'.join([e.strip() for e in maybe_events if e.strip()])
-    events_list = events.splitlines()
-    return events_list
+    maybe_events = [lines[i] for i in
+        range(lines.index('== Events =='), lines.index('== Births =='))]
+    # Remove section headers
+    events = [line for line in maybe_events if not line.startswith('=')]
+    for event in events:
+        print(event)
+    return events
 
 
 def get_tweet_str():


### PR DESCRIPTION
This repo is gone. Go back to the buggy wikipedia module, with workaround.

Take the lesser of two poisons.